### PR TITLE
added language selector to post meta

### DIFF
--- a/layouts/partials/language-selector.html
+++ b/layouts/partials/language-selector.html
@@ -1,0 +1,14 @@
+{{ $siteLanguages := site.Languages}}
+{{ $pageLang := .Page.Lang}}
+{{- range .Page.AllTranslations }}
+    {{ $translation := . }}
+    {{- range sort $siteLanguages "Weight" "asc" }}
+        {{- if eq $translation.Lang .Lang }}
+            {{ if eq $pageLang .Lang}}
+                <a class="english-flag" href="{{ $translation.Permalink | relURL }}">{{ .Params.languageName }}{{ .Params.languageFlag }}</a>
+            {{ else }}
+                <a class="norwegian-flag" href="{{ $translation.Permalink | relURL }}">{{ .Params.languageName }}{{ .Params.languageFlag }}</a>
+            {{ end }}
+        {{- end }}
+    {{- end }}
+{{- end }}

--- a/layouts/partials/post/meta.html
+++ b/layouts/partials/post/meta.html
@@ -7,4 +7,5 @@
     {{ end }}
     {{ partial "post/category.html" . }}
   </div>
+  {{ partial "language-selector.html" . }}
 {{ end }}


### PR DESCRIPTION
Added links to the translated copies of a post in the meta partial

The links are labelled with the translated langauge name and a suitable flag for each language